### PR TITLE
jb: fix: check db file exists for wallet commands, fixes #11.

### DIFF
--- a/bamwallet/HD/Session.cs
+++ b/bamwallet/HD/Session.cs
@@ -3,7 +3,9 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Security;
+using BAMWallet.Extensions;
 using LiteDB;
 using Newtonsoft.Json.Linq;
 using BAMWallet.Helper;
@@ -21,12 +23,24 @@ namespace BAMWallet.HD
         public WalletTransaction WalletTransaction { get; set; }
         public LiteRepository Database { get; set; }
 
+        private bool DbExists => File.Exists(Util.WalletPath(Identifier.ToUnSecureString()));
+
         public Session(SecureString identifier, SecureString passphrase)
         {
             Identifier = identifier;
             Passphrase = passphrase;
             SessionId = Guid.NewGuid();
             Database = Util.LiteRepositoryFactory(identifier, passphrase);
+        }
+
+        public Session EnforceDbExists()
+        {
+            if (!DbExists)
+            {
+                throw new FileNotFoundException("Unable to find wallet file with given identifier");
+            }
+
+            return this;
         }
 
         /// <summary>

--- a/cli/ApplicationLayer/Commands/Wallet/WalletTxHistoryCommand.cs
+++ b/cli/ApplicationLayer/Commands/Wallet/WalletTxHistoryCommand.cs
@@ -49,15 +49,20 @@ namespace CLi.ApplicationLayer.Commands.Wallet
                    if (!request.Success)
                    {
                        _console.ForegroundColor = ConsoleColor.Red;
-                       _console.WriteLine("Wallet history request failed.");
+                       _console.WriteLine("\nWallet history request failed.");
+
+                       if (request.NonSuccessMessage != null)
+                       {
+                           _console.WriteLine($"{request.NonSuccessMessage}");
+                       }
                        _console.ForegroundColor = ConsoleColor.White;
-                       return null;
+                       return Task.CompletedTask;
                    }
 
                    if (!request.Result.Any())
                    {
                        NoTxn();
-                       return null;
+                       return Task.CompletedTask;
                    }
 
                    var table = new ConsoleTable("DateTime", "Memo", "MoneyOut", "Fee", "MoneyIn", "Reward", "Balance");


### PR DESCRIPTION
Fixes #11 

- Added _EnforceDbExists_ method to _Session_ to allow validating the database file already exists
- Modified wallet service methods to utilize _EnforceDbExists_
- Fixed null-reference exception when calling _history_ command and history request is Unsuccesful