### PR TITLE
feat: store isValid flag when tx is confirmed on chain

### DIFF
--- a/bamwallet/HD/Constant.cs
+++ b/bamwallet/HD/Constant.cs
@@ -7,15 +7,15 @@ namespace BAMWallet.HD
     {
         public const string Mainnet = "mainnet";
         public const string Testnet = "testnet";
-        
+
         public const int NanoTan = 1000_000_000;
-        
+
         public const string AppSettingsFile = "appsettings.json";
         public const string AppSettingsFileDev = "appsettings.Development.json";
-        
+
         public const string ConfigSectionNameLog = "Log";
         public const string ConfigSectionNameConfigVersion = "ConfigVersion";
-        
+
         public const int MinimumConfigVersion = 1;
     }
 }

--- a/bamwallet/HD/WalletService.cs
+++ b/bamwallet/HD/WalletService.cs
@@ -466,7 +466,7 @@ namespace BAMWallet.HD
                 }));
             }
 
-            var saved = Save(session, session.WalletTransaction, true);
+            var saved = Save(session, session.WalletTransaction, false);
             if (!saved.Success)
                 return TaskResult<WalletTransaction>.CreateFailure(JObject.FromObject(new
                 {
@@ -1210,7 +1210,7 @@ namespace BAMWallet.HD
         private async Task SyncTransactions(Session session, IEnumerable<WalletTransaction> transactions)
         {
             var walletTransactions = transactions.ToList();
-            
+
             foreach (var transaction in walletTransactions.Select(walletTransaction => walletTransaction.Transaction))
             {
                 if (await TransactionDoesNotExist(transaction))
@@ -1223,7 +1223,7 @@ namespace BAMWallet.HD
                     }
                 }
             }
-            
+
             foreach (var transaction in walletTransactions.Where(walletTransaction => walletTransaction.IsVerified))
             {
                 if (await TransactionExistsInEndpoint(transaction, _networkSettings.Routing.TransactionId))
@@ -1267,8 +1267,8 @@ namespace BAMWallet.HD
 
             return true;
         }
-        
-        
+
+
         private async Task<bool> TransactionExistsInEndpoint(WalletTransaction transaction, string endpoint)
         {
             var baseAddress = _client.GetBaseAddress();
@@ -1447,7 +1447,7 @@ namespace BAMWallet.HD
             return TaskResult<bool>.CreateSuccess(true);
         }
 
-        
+
         public TaskResult<bool> Update<T>(Session session, T data)
         {
             Guard.Argument(data, nameof(data)).NotEqual(default);
@@ -1465,7 +1465,7 @@ namespace BAMWallet.HD
             return TaskResult<bool>.CreateSuccess(true);
         }
 
-        
+
         /// <summary>
         ///
         /// </summary>

--- a/bamwallet/Model/BalanceSheet.cs
+++ b/bamwallet/Model/BalanceSheet.cs
@@ -14,6 +14,7 @@ namespace BAMWallet.Model
         public string Balance { get; set; }
         public Vout[] Outputs { get; set; }
         public string TxId { get; set; }
+        public bool IsVerified { get; set; }
         public bool? IsLocked { get; set; }
     }
 }

--- a/bamwallet/Model/Transaction.cs
+++ b/bamwallet/Model/Transaction.cs
@@ -24,6 +24,7 @@ namespace BAMWallet.Model
         [Key(5)] public Vout[] Vout { get; set; }
         [Key(6)] public RCT[] Rct { get; set; }
         [Key(7)] public Vtime Vtime { get; set; }
+
         /// <summary>
         /// 
         /// </summary>

--- a/bamwallet/Model/WalletTransaction.cs
+++ b/bamwallet/Model/WalletTransaction.cs
@@ -23,5 +23,6 @@ namespace BAMWallet.Model
         public Transaction Transaction { get; set; }
         public WalletType WalletType { get; set; }
         public int Delay { get; set; }
+        public bool IsVerified { get; set; }
     }
 }

--- a/cli/ApplicationLayer/Commands/CommandService.cs
+++ b/cli/ApplicationLayer/Commands/CommandService.cs
@@ -249,9 +249,7 @@ namespace CLi.ApplicationLayer.Commands
 
             foreach (var hostedProvider in hostedProviders)
             {
-                var serviceInstance = _serviceProvider.GetService(hostedProvider) as IHostedService;
-
-                if (serviceInstance != null)
+                if (_serviceProvider.GetService(hostedProvider) is IHostedService serviceInstance)
                 {
                     await serviceInstance.StartAsync(new CancellationToken());
                 }

--- a/cli/ApplicationLayer/Commands/Wallet/WalletTransferCommand.cs
+++ b/cli/ApplicationLayer/Commands/Wallet/WalletTransferCommand.cs
@@ -62,7 +62,8 @@ namespace CLi.ApplicationLayer.Commands.Wallet
                             Payment = t.ConvertToUInt64(),
                             RecipientAddress = address,
                             WalletType = WalletType.Send,
-                            Delay = delay
+                            Delay = delay,
+                            IsVerified = false
                         };
 
                         _walletService.CreateTransaction(session);

--- a/cli/ApplicationLayer/Commands/Wallet/WalletTxHistoryCommand.cs
+++ b/cli/ApplicationLayer/Commands/Wallet/WalletTxHistoryCommand.cs
@@ -63,8 +63,16 @@ namespace CLi.ApplicationLayer.Commands.Wallet
                         return Task.CompletedTask;
                     }
 
-                    var table = new ConsoleTable("DateTime", "Payment Id", "Memo", "Money In", "Money Out", "Reward",
-                        "Balance", "Locked");
+                    var table = new ConsoleTable(
+                        "DateTime",
+                        "Payment Id",
+                        "Memo",
+                        "Money In",
+                        "Money Out",
+                        "Reward",
+                        "Balance",
+                        "Verified",
+                        "Locked");
 
                     foreach (var sheet in request.Result)
                     {
@@ -76,6 +84,7 @@ namespace CLi.ApplicationLayer.Commands.Wallet
                             sheet.MoneyOut,
                             sheet.Reward,
                             sheet.Balance,
+                            sheet.IsVerified.ToString(),
                             sheet.IsLocked.ToString());
                     }
 

--- a/cli/Program.cs
+++ b/cli/Program.cs
@@ -65,7 +65,7 @@ namespace Cli
                 await Console.Error.WriteLineAsync($"Configuration file outdated. Please delete appsettings.json and create a new one running 'clibamwallet --configure'");
                 return 1;
             }
-            
+
             if (config.GetSection(Constant.ConfigSectionNameLog) != null)
             {
                 Log.Logger = new LoggerConfiguration()


### PR DESCRIPTION
Wallets contain transactions that are both on the chain as well as in the mempool. Mempool transactions get purged eventually, but on-chain transactions are permanent. This flag indicates whether or not a transaction is confirmed on the chain.

The background task syncing the wallet's transactions only needs to check those transactions that are not yet marked as valid.