### PR TITLE
Temporarily comment out sync msg.

### DIFF
--- a/cli/ApplicationLayer/Commands/Wallet/SyncCommand.cs
+++ b/cli/ApplicationLayer/Commands/Wallet/SyncCommand.cs
@@ -35,10 +35,10 @@ namespace CLi.ApplicationLayer.Commands.Wallet
         {
             if (Command.ActiveSession != null)
             {
-                _console.WriteLine("Syncing wallet with chain ...");
-                _console.ForegroundColor = ConsoleColor.Cyan;
-                _console.Write("bamboo$ ");
-                _console.ForegroundColor = ConsoleColor.White;
+                // _console.WriteLine("Syncing wallet with chain ...");
+                // _console.ForegroundColor = ConsoleColor.Cyan;
+                // _console.Write("bamboo$ ");
+                // _console.ForegroundColor = ConsoleColor.White;
                 await _walletService.SyncWallet(Command.ActiveSession);
             }
         }


### PR DESCRIPTION
- Removes msg from sync command.
- This is a workaround. The actual problem is that command execution is not synchronized. Same issue will occur when RPC command arrives at the same time with local console command.