### PR TITLE
Remove change/coinstake spendable age.

### DIFF
--- a/bamwallet/Model/Transaction.cs
+++ b/bamwallet/Model/Transaction.cs
@@ -193,13 +193,13 @@ namespace BAMWallet.Model
         /// 
         /// </summary>
         /// <returns></returns>
-        public bool IsLockedOrInvalid(Key scan)
+        public bool IsLockedOrInvalid()
         {
             return Vout.Length switch
             {
-                1 => Vout[0].IsLockedOrInvalid(scan),
-                2 => Vout[1].IsLockedOrInvalid(scan),
-                _ => Vout[0].IsLockedOrInvalid(scan)
+                1 => Vout[0].IsLockedOrInvalid(),
+                2 => Vout[1].IsLockedOrInvalid(),
+                _ => Vout[0].IsLockedOrInvalid()
             };
         }
     }

--- a/bamwallet/Model/Vout.cs
+++ b/bamwallet/Model/Vout.cs
@@ -24,17 +24,9 @@ namespace BAMWallet.Model
         /// 
         /// </summary>
         /// <returns></returns>
-        public bool IsLockedOrInvalid(Key scan = null)
+        public bool IsLockedOrInvalid()
         {
-            if (T == CoinType.Payment)
-            {
-                return scan == null || Transaction.Amount(this, scan) == 0;
-            }
-
-            if (L == 0)
-            {
-                return true;
-            }
+            if (T != CoinType.Coinbase) return false;
 
             var lockTime = new LockTime(Utils.UnixTimeToDateTime(L));
             var script = S;
@@ -52,6 +44,7 @@ namespace BAMWallet.Model
             spending.Inputs.Add(new TxIn(tx.Outputs.AsCoins().First().Outpoint, new Script()));
             spending.Inputs[0].Sequence = 1;
             return !spending.Inputs.AsIndexedInputs().First().VerifyScript(tx.Outputs[0]);
+
         }
     }
 }


### PR DESCRIPTION
Spendable age is not required as transactions are not referenced using an offset.