### PR TITLE
fix: negated constant pattern check if object is false

### DIFF
--- a/cli/Commands/CmdLine/WalletTransferCommand.cs
+++ b/cli/Commands/CmdLine/WalletTransferCommand.cs
@@ -70,7 +70,7 @@ namespace Cli.Commands.CmdLine
                             else
                             {
                                 var sendResult = _walletService.Send(session, ref transaction);
-                                if (sendResult.Item1 is null)
+                                if (sendResult.Item1 is not true)
                                 {
                                     spinner.Fail(sendResult.Item2);
                                 }


### PR DESCRIPTION
When the spend transaction fails the return tuple object item is set too false.