### PR TITLE
Wallet RCP create transaction

### DIFF
--- a/bamwallet/HD/CommandReceiver.cs
+++ b/bamwallet/HD/CommandReceiver.cs
@@ -1150,19 +1150,18 @@ namespace BAMWallet.HD
                 _logger.Here().Error(ex, "Error getting history");
                 return new Tuple<object, string>(null, ex.Message);
             }
-
+            
             return new Tuple<object, string>(balanceSheets.OrderBy(x => x.Date), String.Empty);
         }
 
         public bool IsTransactionAllowed(in Session session)
         {
-            return true;
-            // //will mark as verified all possible transaction/remove broken transactions
-            // SyncWallet(session);
-            // //if there are still non verified but in mempool transactions return false, else we're good to go
-            // bool doesUnverifiedTransactionExist = session.Database.Query<WalletTransaction>().Where(x => !x.IsVerified)
-            //     .ToList().Any();
-            // return (doesUnverifiedTransactionExist == false);
+            //will mark as verified all possible transaction/remove broken transactions
+            SyncWallet(session);
+            //if there are still non verified but in mempool transactions return false, else we're good to go
+            bool doesUnverifiedTransactionExist = session.Database.Query<WalletTransaction>().Where(x => !x.IsVerified)
+                .ToList().Any();
+            return (doesUnverifiedTransactionExist == false);
         }
 
         /// <summary>

--- a/bamwallet/HD/CommandReceiver.cs
+++ b/bamwallet/HD/CommandReceiver.cs
@@ -10,7 +10,6 @@ using Dawn;
 using Libsecp256k1Zkp.Net;
 using Microsoft.Extensions.Options;
 using NBitcoin;
-using NBitcoin.Stealth;
 using Newtonsoft.Json.Linq;
 using Serilog;
 using System;
@@ -22,6 +21,7 @@ using System.Net;
 using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
+using NBitcoin.Stealth;
 using Block = BAMWallet.Model.Block;
 using Transaction = BAMWallet.Model.Transaction;
 using Util = BAMWallet.Helper.Util;
@@ -192,7 +192,6 @@ namespace BAMWallet.HD
             {
                 var (outPkPayment, stealthPayment) = StealthPayment(transaction.RecipientAddress);
                 var (outPkChange, stealthChange) = StealthPayment(transaction.SenderAddress);
-                var coinstakeLockTime = new LockTime(Utils.DateTimeToUnixTime(DateTimeOffset.UtcNow.AddSeconds(15)));
                 var tx = new Transaction
                 {
                     Bp = new[] { new Bp { Proof = bp } },
@@ -207,7 +206,6 @@ namespace BAMWallet.HD
                             A = session.SessionType == SessionType.Coinstake ? transaction.Payment : 0,
                             C = pcmOut[0],
                             E = stealthPayment.Metadata.EphemKey.ToBytes(),
-                            L = session.SessionType == SessionType.Coinstake ? coinstakeLockTime.Value : 0,
                             N = ScanPublicKey(transaction.RecipientAddress).Encrypt(
                                 Transaction.Message(transaction.Payment, 0, blinds[1],
                                     transaction.Memo)),
@@ -234,7 +232,7 @@ namespace BAMWallet.HD
                     using var pedersen = new Pedersen();
 
                     var (outPkReward, stealthReward) = StealthPayment(transaction.SenderAddress);
-                    var rewardLockTime = new LockTime(Utils.DateTimeToUnixTime(DateTimeOffset.UtcNow.AddHours(21)));
+                    var rewardLockTime = new LockTime(Util.DateTimeToUnixTime(DateTimeOffset.UtcNow.AddHours(21)));
                     var blind = pedersen.BlindSwitch(transaction.Reward, secp256K1.CreatePrivateKey());
                     var commit = pedersen.Commit(transaction.Reward, blind);
                     var vOutput = tx.Vout.ToList();

--- a/bamwallet/HD/CommandReceiver.cs
+++ b/bamwallet/HD/CommandReceiver.cs
@@ -295,7 +295,7 @@ namespace BAMWallet.HD
                 }
 
                 var timer = new Stopwatch();
-                var t = (int)(walletTransaction.Delay * 2.7 * 1000);
+                var t =  (int)(walletTransaction.Delay * 4.5 * 1000);
                 timer.Start();
                 var nonce = Cryptography.Sloth.Eval(t, x);
                 timer.Stop();
@@ -314,8 +314,11 @@ namespace BAMWallet.HD
 
                 if (timer.Elapsed.Seconds < 5)
                 {
-                    walletTransaction.Delay++;
-                    GenerateTransactionTime(session, transaction, ref walletTransaction);
+                    return TaskResult<Transaction>.CreateFailure(JObject.FromObject(new
+                    {
+                        success = false,
+                        message = "Verified delayed function elapsed seconds is lower the than the default amount"
+                    }));
                 }
 
                 var lockTime = Util.GetAdjustedTimeAsUnixTimestamp() & ~timer.Elapsed.Seconds;
@@ -343,9 +346,10 @@ namespace BAMWallet.HD
         }
 
         /// <summary>
-        ///
+        /// 
         /// </summary>
         /// <param name="session"></param>
+        /// <param name="spending"></param>
         /// <param name="blinds"></param>
         /// <param name="sk"></param>
         /// <param name="nRows"></param>

--- a/bamwallet/Helper/Util.cs
+++ b/bamwallet/Helper/Util.cs
@@ -109,5 +109,41 @@ namespace BAMWallet.Helper
         {
             return new DateTimeOffset(GetAdjustedTime()).ToUnixTimeSeconds();
         }
+        
+        static DateTimeOffset unixRef = new DateTimeOffset(1970, 1, 1, 0, 0, 0, TimeSpan.Zero);
+        
+        public static uint DateTimeToUnixTime(DateTimeOffset dt)
+        {
+            return (uint)DateTimeToUnixTimeLong(dt);
+        }
+
+        internal static ulong DateTimeToUnixTimeLong(DateTimeOffset dt)
+        {
+            dt = dt.ToUniversalTime();
+            if (dt < unixRef)
+                throw new ArgumentOutOfRangeException("The supplied datetime can't be expressed in unix timestamp");
+            var result = (dt - unixRef).TotalSeconds;
+            if (result > UInt32.MaxValue)
+                throw new ArgumentOutOfRangeException("The supplied datetime can't be expressed in unix timestamp");
+            return (ulong)result;
+        }
+
+        public static DateTimeOffset UnixTimeToDateTime(uint timestamp)
+        {
+            var span = TimeSpan.FromSeconds(timestamp);
+            return unixRef + span;
+        }
+        
+        public static DateTimeOffset UnixTimeToDateTime(ulong timestamp)
+        {
+            var span = TimeSpan.FromSeconds(timestamp);
+            return unixRef + span;
+        }
+        
+        public static DateTimeOffset UnixTimeToDateTime(long timestamp)
+        {
+            var span = TimeSpan.FromSeconds(timestamp);
+            return unixRef + span;
+        }
     }
 }

--- a/bamwallet/Model/Vout.cs
+++ b/bamwallet/Model/Vout.cs
@@ -28,7 +28,7 @@ namespace BAMWallet.Model
         {
             if (T != CoinType.Coinbase) return false;
 
-            var lockTime = new LockTime(Utils.UnixTimeToDateTime(L));
+            var lockTime = new LockTime(Helper.Util.UnixTimeToDateTime(L));
             var script = S;
             var sc1 = new Script(Op.GetPushOp(lockTime.Value), OpcodeType.OP_CHECKLOCKTIMEVERIFY);
             var sc2 = new Script(script);

--- a/bamwallet/bamwallet.csproj
+++ b/bamwallet/bamwallet.csproj
@@ -39,11 +39,11 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Blake3" Version="0.3.0" />
-    <PackageReference Include="MessagePack" Version="2.2.85" />
+    <PackageReference Include="MessagePack" Version="2.3.75" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Dawn.Guard" Version="1.12.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="LiteDB" Version="5.0.10" />
+    <PackageReference Include="LiteDB" Version="5.0.11" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="NBitcoin" Version="5.0.83" />
@@ -54,7 +54,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.1.4" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.1" />
     <PackageReference Include="WebApiContrib.Core.Formatter.Bson" Version="2.1.0" />
     <PackageReference Include="libsecp256k1Zkp.Net" Version="1.1.9" />
   </ItemGroup>

--- a/cli/cli.csproj
+++ b/cli/cli.csproj
@@ -38,14 +38,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FuzzySharp" Version="1.0.0" />
+    <PackageReference Include="FuzzySharp" Version="2.0.2" />
     <PackageReference Include="Kurukuru" Version="1.3.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.1.0" />
     <PackageReference Include="ConsoleTables" Version="2.4.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" />
     <PackageReference Include="runtime.native.System.IO.Compression" Version="4.3.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.0" />


### PR DESCRIPTION
- VDF cycle amounts lower than 5 secs causing timeouts and undesirable behaviour. 
- Removing coinsstake time-lock.
- Bring DateTimeToUnixTime into project as reference is undiscoverable.